### PR TITLE
Add Stampery Trailbot Watcher artifact

### DIFF
--- a/baas-artifacts/linux-stampery-trailbot-watcher/README.md
+++ b/baas-artifacts/linux-stampery-trailbot-watcher/README.md
@@ -1,0 +1,9 @@
+![Trailbot Watcher on Ubuntu](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/stampery-trailbot-ubuntu/images/banner.png)
+
+# Trailbot Watcher
+
+This template installs a special demon called __Trailbot Watcher__ that monitors system logs and files, triggers __Smart Policies__ upon potentially unwanted modification and generates a blockchain-anchored, immutable __audit trail__ of everything happening to them.
+
+## Trouble?
+
+Feel free to post an issue in our [GitHub repository](https://github.com/trailbot/client/issues) or ping support@trailbot.com for more information.

--- a/baas-artifacts/linux-stampery-trailbot-watcher/artifactfile.json
+++ b/baas-artifacts/linux-stampery-trailbot-watcher/artifactfile.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Azure/azure-devtestlab/master/schemas/2015-01-01/dtlArtifacts.json",
+  "title": "Trailbot Watcher",
+  "description": "Trailbot Watcher monitors your system files and logs, triggers Smart Policies upon unwanted modification and generates a __blockchain-anchored__, __immutable audit trail__ of everything happening to them.",
+  "iconUri": "https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-trailbot-watcher/labArtifact.png",
+  "targetOsType": "Linux",
+  "parameters": {
+    "adminEmail": {
+      "type": "string",
+      "metadata": {
+        "description": "Your email address."
+      }
+    },
+    "clientPubKey": {
+      "type": "string",
+      "metadata": {
+        "description": "Client public key. Please install Trailbot Client in your personal computer, open it and it will generate a key you must paste here."
+      }
+    },
+  },
+  "runCommand": {
+    "commandToExecute": "[concat('sh install.sh \"', parameters('adminEmail'), '\" ', parameters('clientPubKey'))]"
+  }
+}

--- a/baas-artifacts/linux-stampery-trailbot-watcher/install.sh
+++ b/baas-artifacts/linux-stampery-trailbot-watcher/install.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -e
+
+#################################################################
+# Update Ubuntu and install prerequisites for running Trailbot  #
+#################################################################
+curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+DEBIAN_FRONTEND=noninteractive apt-get install -y git nodejs rng-tools mailutils build-essential
+
+#################################################################
+# Get the watcher code and install its npm dependencies         #
+#################################################################
+git clone https://github.com/trailbot/watcher
+cd watcher
+git checkout azure
+npm install --production --ignore-scripts
+
+#################################################################
+# Fake setup                                                    #
+#################################################################
+mkdir .localstorage
+echo "[\"azure\"]" > .localstorage/mods
+echo "vault.trailbot.io:8443" > .localstorage/vault
+echo "$1" > .localstorage/user_email
+echo -e "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\n" > .localstorage/client_pub_key
+echo -e $(echo "$2" | sed 's/  /@/g' | cut -d@ -f2 | cut -d- -f1 | sed 's/ /\\n/g') >> .localstorage/client_pub_key
+echo -e "\n-----END PGP PUBLIC KEY BLOCK-----" >> .localstorage/client_pub_key
+
+#################################################################
+# Keypar generation                                             #
+#################################################################
+rngd -r /dev/urandom
+gpg --batch --armor --gen-key <<EOF
+  Key-Type: RSA
+  Key-Length: 4096
+  Subkey-Type: RSA
+  Subkey-Length: 4096
+  Name-Real: "$(hostname)"
+  Name-Email: "watcher@$(hostname)"
+  Expire-Date: 0
+  %no-protection
+  %secring .localstorage/watcher_priv_key
+  %pubring .localstorage/watcher_pub_key
+  %echo Generating keypar...
+  %commit
+  %echo Keypar generated successfully!
+EOF
+
+#################################################################
+# Send public key to admin via email                            #
+#################################################################
+echo "Please find enclosed the public key for the Trailbot Watcher \
+installed at $(hostname)" | mail \
+  -a ".localstorage/watcher_pub_key" \
+  -s "Successful installation of Trailbot Watcher at $(hostname)" \
+  $1
+
+#################################################################
+# Service creation and start up                                 #
+#################################################################
+sh scripts/service
+exit 0


### PR DESCRIPTION
### Changelog
* Add Stampery's "Trailbot Watcher"  for GNU/Linux.

### Description of the change
This commit adds an artifact for installing __Trailbot Watcher__, a special demon that monitors system logs and files, triggers __Smart Policies__ upon potentially unwanted modification and generates a __blockchain-anchored__, __immutable audit trail__ of everything happening to them.

[__Smart Policies__](https://github.com/trailbot/client/wiki/Smart-Policies) are simple scripts that get called every time a tracked log or file changes. They trigger actions such as emailing someone, rolling files back or even shutting the system down. There are [plenty of them ready to use](https://github.com/trailbot/client/wiki/Smart-Policies#ready-to-use-policies), and you can even [create your own](https://github.com/trailbot/client/wiki/Smart-Policies).
