### PR TITLE
add elementrem CLI update script commands (0.9)

### DIFF
--- a/baas-artifacts/linux-elementrem-smartcontract/README.md
+++ b/baas-artifacts/linux-elementrem-smartcontract/README.md
@@ -47,6 +47,11 @@ https://github.com/elementrem/
 
 ***
 
+- You can update gele with the latest version whenever you want.	
+Elementrem Gele update		
+Run `$ sh ./update-gele.sh`
+- Update does not affect your chain,DB,key data. Rest assured on that.		
+
 **1. Select the desired node Elementrem.**
 - Elementrem public node
 Run `$ sh ./start_public.sh`

--- a/baas-artifacts/linux-elementrem-smartcontract/build_elementrem.sh
+++ b/baas-artifacts/linux-elementrem-smartcontract/build_elementrem.sh
@@ -45,7 +45,7 @@ rm go1.6.2.linux-amd64.tar.gz
 git clone https://github.com/elementrem/go-elementrem/
 
 # Build elementrem
-cd  go-elementrem
+cd go-elementrem
 git checkout Azure
 make gele
 cd

--- a/baas-artifacts/linux-elementrem-smartcontract/update-gele.sh
+++ b/baas-artifacts/linux-elementrem-smartcontract/update-gele.sh
@@ -1,0 +1,18 @@
+# Delete old Version
+sudo rm /usr/bin/gele
+
+# Downloads git source
+cd $HOME
+git clone https://github.com/elementrem/go-elementrem/
+
+# Build elementrem
+cd go-elementrem
+git checkout Azure
+make
+
+# gele path to usr/bin/
+cd $HOME
+cd go-elementrem/build/bin
+sudo cp gele /usr/bin
+cd $HOME
+rm -rf go-elementrem


### PR DESCRIPTION
Gele CLI 1.4.14 (Azure Branch) upgrade has been completed.
Use `$ sh ./update-gele.sh` command to upgrade the gele to the latest version.
Always have access to the latest gele releases. 
This activity can require constant maintenance and gele will be continually reviewed and upgraded.