### PR TITLE
build_elementrem.sh : More appropriately care for build script.

### DIFF
--- a/baas-artifacts/linux-elementrem-smartcontract/README.md
+++ b/baas-artifacts/linux-elementrem-smartcontract/README.md
@@ -11,7 +11,7 @@
 ***
 
 - Recommend that Ubuntu Server 16.04 LTS		
-- VM(Virtual machine) installation process takes approximately 30 minutes.	
+- VM(Virtual machine) installation process takes approximately 15 minutes.	
 - VM size must be at least A1. ***(If you use A0, The build will fail.)***				
 - If you run mining and meteor wallet at the same time, ***VM size must be at least A2.***		
 - Elementrem Network listening port = 30707 (Using the `Azure Network security group` to open the port.)

--- a/baas-artifacts/linux-elementrem-smartcontract/build_elementrem.sh
+++ b/baas-artifacts/linux-elementrem-smartcontract/build_elementrem.sh
@@ -79,7 +79,6 @@ wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/e
 wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/attach_public.sh
 wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/start_private.sh
 wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/start_public.sh
-wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/private_prerequisites.json
 wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/meteor-wallet-setup.sh
 wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/update-gele.sh
 

--- a/baas-artifacts/linux-elementrem-smartcontract/build_elementrem.sh
+++ b/baas-artifacts/linux-elementrem-smartcontract/build_elementrem.sh
@@ -24,6 +24,7 @@ wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/ba
 wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-elementrem-smartcontract/start_public.sh
 wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-elementrem-smartcontract/private_prerequisites.json
 wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-elementrem-smartcontract/meteor-wallet-setup.sh
+wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-elementrem-smartcontract/update-gele.sh
 
 # Initialize
 cd $HOMEDIR

--- a/baas-artifacts/linux-elementrem-smartcontract/build_elementrem.sh
+++ b/baas-artifacts/linux-elementrem-smartcontract/build_elementrem.sh
@@ -75,12 +75,12 @@ echo "{
 
 # Downloads scripts
 cd $HOMEDIR
-wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/attach_private.sh
-wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/attach_public.sh
-wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/start_private.sh
-wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/start_public.sh
-wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/meteor-wallet-setup.sh
-wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/update-gele.sh
+wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-elementrem-smartcontract/attach_private.sh
+wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-elementrem-smartcontract/attach_public.sh
+wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-elementrem-smartcontract/start_private.sh
+wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-elementrem-smartcontract/start_public.sh
+wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-elementrem-smartcontract/meteor-wallet-setup.sh
+wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-elementrem-smartcontract/update-gele.sh
 
 # Initialize private network
 cd $HOMEDIR

--- a/baas-artifacts/linux-elementrem-smartcontract/build_elementrem.sh
+++ b/baas-artifacts/linux-elementrem-smartcontract/build_elementrem.sh
@@ -8,33 +8,20 @@ date
 ps axjf
 
 # Parameters
-
 AZUREUSER=$1
+EXDATA=`echo "$2" | xxd -plain -c 250`
 HOMEDIR="/home/$AZUREUSER"
 VMNAME=`hostname`
 echo "User: $AZUREUSER"
 echo "User home dir: $HOMEDIR"
 echo "vmname: $VMNAME"
 
-# Downloads scripts
-cd $HOMEDIR
-wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-elementrem-smartcontract/attach_private.sh
-wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-elementrem-smartcontract/attach_public.sh
-wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-elementrem-smartcontract/start_private.sh
-wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-elementrem-smartcontract/start_public.sh
-wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-elementrem-smartcontract/private_prerequisites.json
-wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-elementrem-smartcontract/meteor-wallet-setup.sh
-wget https://raw.githubusercontent.com/Azure/azure-blockchain-projects/master/baas-artifacts/linux-elementrem-smartcontract/update-gele.sh
-
 # Initialize
 cd $HOMEDIR
-sudo apt -y update
-sudo apt -y upgrade
 sudo apt-get install -y git curl wget
 
-
 # Install go-lang
-sudo apt-get install -y build-essential libgmp3-dev golang git curl
+sudo apt-get install -y build-essential libgmp3-dev golang
 
 # Downloads git source 
 git clone https://github.com/elementrem/go-elementrem/
@@ -69,12 +56,11 @@ sudo apt-get -y install libboost-filesystem-dev
 sudo apt-get -f -y install
 sudo dpkg -i libboost-filesystem-dev_1.58.0.1ubuntu1_amd64.deb
 sudo dpkg -i solc_0.3.6-0ubuntu1~xenial_amd64.deb
-cd ..
+cd $HOMEDIR
 rm -rf solidity
 
 # Initialize private_genesis_Block
-exdata=`echo "$2" | xxd -plain -c 250`
-
+cd $HOMEDIR
 echo "{
   \"alloc\": {},
   \"nonce\": \"0x0000000000000000\",
@@ -83,9 +69,19 @@ echo "{
   \"coinbase\": \"0x0000000000000000000000000000000000000000\",
   \"timestamp\": \"0x00\",
   \"parentHash\": \"0x0000000000000000000000000000000000000000000000000000000000000000\",
-  \"extraData\": \"0x$exdata\",
+  \"extraData\": \"0x$EXDATA\",
   \"gasLimit\": \"0x2FEFD8\"
 }" > private_prerequisites.json
+
+# Downloads scripts
+cd $HOMEDIR
+wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/attach_private.sh
+wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/attach_public.sh
+wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/start_private.sh
+wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/start_public.sh
+wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/private_prerequisites.json
+wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/meteor-wallet-setup.sh
+wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elementrem-smartcontract-blockchain/update-gele.sh
 
 # Initialize private network
 cd $HOMEDIR

--- a/baas-artifacts/linux-elementrem-smartcontract/build_elementrem.sh
+++ b/baas-artifacts/linux-elementrem-smartcontract/build_elementrem.sh
@@ -35,12 +35,6 @@ sudo apt-get install -y git curl wget
 
 # Install go-lang
 sudo apt-get install -y build-essential libgmp3-dev golang git curl
-curl -O https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.6.2.linux-amd64.tar.gz
-mkdir -p ~/go; echo "export GOPATH=$HOME/go" >> ~/.bashrc
-echo "export PATH=$PATH:$HOME/go/bin:/usr/local/go/bin" >> ~/.bashrc
-source ~/.bashrc
-rm go1.6.2.linux-amd64.tar.gz
 
 # Downloads git source 
 git clone https://github.com/elementrem/go-elementrem/


### PR DESCRIPTION
build_elementrem.sh
- download the `update-gele.sh` script.(I accidentally left out `wget update-gele` at previouse PR)
- More appropriately care for build script.(More fast build & stable)

Elementrem Gele CLI 1.4.17 upgrade has been completed. 
Testing has completed successfully on the network. This is a very stable version. 
It has also been applied to Azure Branch. https://github.com/elementrem/go-elementrem/tree/Azure

Thanks @marleyg !